### PR TITLE
Cleanup sessions during create

### DIFF
--- a/src/main/php/web/session/InMongoDB.class.php
+++ b/src/main/php/web/session/InMongoDB.class.php
@@ -24,8 +24,13 @@ class InMongoDB extends Sessions {
    * @return web.session.ISession
    */
   public function create() {
-    $this->collection->insert($values= new Document(['_created' => time()]));
-    return new Session($this, $this->collection, $values, time() + $this->duration, true);
+    $now= time();
+    $this->collection->insert($values= new Document(['_created' => $now]));
+
+    // Clean up expired sessions while we're here.
+    $this->collection->delete(['_created' => ['$lt' => $now - $this->duration]]);
+
+    return new Session($this, $this->collection, $values, $now + $this->duration, true);
   }
 
   /**

--- a/src/test/php/web/session/mongo/unittest/MongoTest.class.php
+++ b/src/test/php/web/session/mongo/unittest/MongoTest.class.php
@@ -67,8 +67,16 @@ class MongoTest {
 
       public function delete($query, Session $session= null): Delete {
 
-        // Query will always be an ObjectId
-        unset($this->lookup[$query->string()]);
+        // Query will either be an ObjectId or [_created => [$lt => time()]]
+        if ($query instanceof ObjectId) {
+          unset($this->lookup[$query->string()]);
+        } else {
+          foreach ($this->lookup as $id => $document) {
+            if ($document['_created'] < $query['_created']['$lt']) {
+              unset($this->lookup[$id]);
+            }
+          }
+        }
         return new Delete([], [$query]);
       }
     };


### PR DESCRIPTION
This makes session creating a bit more expensive but makes this library work without creating a [TTL index](https://www.mongodb.com/docs/manual/core/index-ttl/)